### PR TITLE
feat: Disable BizCharts telemetry

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,6 +10,11 @@ import { prepareLogs } from './redux/utils';
 import Action from './redux/ActionType';
 import './less/main.less'
 
+import BizCharts from 'bizcharts';
+
+// Disable telemetry (https://github.com/alibaba/BizCharts/issues/143)
+BizCharts.track(false);
+
 class Websocket {
     
     constructor(store) {


### PR DESCRIPTION
Prevents the loading of a pixel for diagnostics.

As mentioned on the forum: https://safenetforum.org/t/crust-test-nat-traversal-join-the-live-test/25799/122?u=bzee

And as an issue on BizCharts: https://github.com/alibaba/BizCharts/issues/143

Not sure if the solution is in the right place.